### PR TITLE
AWS Native SDK release note

### DIFF
--- a/coming-release/index.md
+++ b/coming-release/index.md
@@ -15,10 +15,15 @@ Here's a sampling of the new features found in Lumberyard [VERSION NUMBER].
 **Topics**
 + [HIGHLIGHT TOPIC 1 HERE]
 + [HIGHLIGHT TOPIC 2 HERE]
++ [AWS Native SDK version update]
 + ...
 
 ### [TOPIC 1]
 
 ### [TOPIC 2]
+
+### [AWS Native SDK version update]
+
+AWS Native SDK version was updated to 1.7.167. Note for Linux users: if your project or a gem depends on AWS Native SDK on Linux (such as Twitch gem) then debug/profile builds requires your Linux configuration to have libssl.so.1.1 and libcrypto.so.1.1 present on your system. Release builds link these libraries staticly, so no changes required for release Linux builds of Lumberyard.
 
 ### ...


### PR DESCRIPTION
Including a new Linux requirement for debug/profile builds that use AWS Native SDK.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
